### PR TITLE
Add a missing step to the compiling instructions.

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -3,12 +3,16 @@ This uses a very old version of the Gameboy Development Kit (GBDK) which has som
 WINDOWS:
 
 Copy the "sdk" branch to the root of a main drive (e.g. C:\sdk, D:\sdk, etc)
+cd /d c:\sdk\gbz80-gb\2-1-5\lib
+make
 cd /d c:\sdk\gbz80-gb\2-1-5\examples\u3
 make
 
 LINUX:
 
 Copy/symlink the "sdk" branch to root directory, then:
+cd /sdk/gbz80-gb/2-1-5/lib
+wine cmd /c make.bat
 cd /sdk/gbz80-gb/2-1-5/examples/u3
 wine cmd /c make.bat
 

--- a/sdk/gbz80-gb/2-1-5/examples/u3/make.bat
+++ b/sdk/gbz80-gb/2-1-5/examples/u3/make.bat
@@ -1,4 +1,3 @@
-@echo off
 ..\..\bin\lcc -Wa-l  -Wf-bo1 -c -o sosaria.o sosaria.c
 ..\..\bin\lcc -Wa-l  -Wf-bo2 -c -o u3tiles.o u3tiles.c
 ..\..\bin\lcc -Wa-l  -Wf-bo3 -c -o intro.o intro.c
@@ -51,3 +50,4 @@
 ..\..\bin\lcc -Wl-m -Wl-yo64 -Wl-ya4 -Wl-yt0x1B -Wl-yp0x143=0x80 -o ult3.gb *.o
 del ..\..\..\..\..\ult3.gb
 move ult3.gb ..\..\..\..\..
+pause

--- a/sdk/gbz80-gb/2-1-5/lib/make.sh
+++ b/sdk/gbz80-gb/2-1-5/lib/make.sh
@@ -1,0 +1,1 @@
+wine cmd /c make.bat


### PR DESCRIPTION
Given that the included GBDK did not have its lib directory compiled,  I added in the missing step to build that directory first.